### PR TITLE
Added requirement for test data and config profile

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,6 +17,7 @@ To be included, every pipeline must come with the following features:
 * Built using Nextflow
 * An [MIT licence](https://choosealicense.com/licenses/mit/)
 * Software bundled using [Docker](https://www.docker.com/) and [Singularity](http://singularity.lbl.gov/)
+* Include a minimal test dataset and a configuration profile named `test`
 * Continuous integration testing
 * Stable release tags
 * Common pipeline structure and usage


### PR DESCRIPTION
I would like propose to include the need to provide a dataset for testing purpose
and the relative configuration profile as a requirement. 

I guess that it's already implicit in the fact of having CI testing, hover it would be 
useful to have a *standard* profile name for that ie. `test` (or whatever else). 

Also maybe it should be highlight that this dataset is expected to allow the execution of the 
pipeline in a few secs (no longer than a minute).