### PR TITLE
 Finished first draft of pipelines list page.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,9 +7,10 @@
     <meta name="theme-color" content="#157878">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
     <link rel="shortcut icon" href="/assets/logo/nf-core-logo-square.png" type="image/png" />
+    <script defer src="https://use.fontawesome.com/releases/v5.0.8/js/all.js"></script>
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
   </head>
-  <body>
+  <body class="page-{{ page.path | remove: '.md' }}">
     <div class="corner-ribbon top-left shadow desktop-only" style="background-color: #ed2067;">
       <a href="https://gitter.im/nf-core/Lobby" target="_blank" title="Open nf-core chat room on Gitter">Chat: Gitter</a>
     </div>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -68,9 +68,9 @@ p {
     }
     #markdown-toc {
         position: absolute;
-        left: 1rem;
+        left: 2rem;
         top: 26rem;
-        width: 18rem;
+        width: 16rem;
         padding-left: 0;
         list-style-type: none;
     }
@@ -81,6 +81,6 @@ p {
     .main-content.has-toc {
         max-width: none;
         padding: 2rem;
-        margin: 0 0 0 19rem;
+        margin: 0 2rem 0 17rem;
     }
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -48,6 +48,73 @@ p {
     color: #a0bbd6;
 }
 
+#production_pipelines, #development_pipelines {
+    margin: 2rem 0;
+    border-bottom: 3px solid #ededed;
+}
+.nf-core-pipelines-list {
+    margin: 0 0 3rem;
+    padding: 0;
+    -webkit-column-width: 25rem;
+    -moz-column-width: 25rem;
+    -o-column-width: 25rem;
+    -ms-column-width: 25rem;
+    column-width: 25rem;
+}
+.nf-core-pipelines-list li {
+    position: relative;
+    display: inline-block;
+    width: 25rem;
+    border: 1px solid #ccc;
+    border-radius: 0.5rem;
+    margin: 0 1rem 2rem 0;
+    padding: 0.8rem 1rem;
+    -webkit-column-break-inside: avoid;
+    page-break-inside: avoid;
+    break-inside: avoid-column;
+}
+#nf-core-repos-dev li {
+    background-color: rgba(236, 220, 195, 0.09);
+    box-shadow: 0 0 12px 0px rgba(179, 68, 4, 0.25);
+}
+#nf-core-repos-prod li {
+    background-color: rgba(179, 228, 201, 0.08);
+    box-shadow: 0 0 12px rgba(25, 120, 119, 0.26);
+}
+.nf-core-pipelines-list .repo_name {
+    margin-bottom: 0;
+}
+.nf-core-pipelines-list .repo_description {
+    margin: 5px 0;
+    font-size: 0.9rem;
+}
+.latest-release::before {
+    content: 'Version: ';
+    font-weight: normal;
+}
+.nf-core-pipelines-list .latest-release {
+    margin: 5px 0;
+    display: inline-block;
+    border: 1px solid #58AD6B;
+    border-radius: 0.2rem;
+    font-size: 0.8rem;
+    background-color: #B5DFBE;
+    padding: 1px 3px;
+    box-shadow: 0 1px 3px #ccc;
+    font-weight: bold;
+}
+.nf-core-pipelines-list .stargazers_count {
+    position: absolute;
+    display: block;
+    top: 1rem;
+    right: 1rem;
+    font-size: 0.8rem;
+    color: #999;
+    text-decoration: none;
+}
+
+
+
 #markdown-toc::before {
     content: 'Table of Contents';
     color: #159957;
@@ -70,7 +137,7 @@ p {
         position: absolute;
         left: 2rem;
         top: 26rem;
-        width: 16rem;
+        width: 25rem;
         padding-left: 0;
         list-style-type: none;
     }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -48,9 +48,15 @@ p {
     color: #a0bbd6;
 }
 
+#pipelines_loading {
+    padding: 0.75rem 1rem;
+    margin: 0;
+    border: 1px solid #ccc;
+    border-radius: 0.3rem;
+    text-align: center;
+}
 #production_pipelines, #development_pipelines {
     margin: 2rem 0;
-    border-bottom: 3px solid #ededed;
 }
 .nf-core-pipelines-list {
     margin: 0 0 3rem;
@@ -66,7 +72,7 @@ p {
     display: inline-block;
     width: 25rem;
     border: 1px solid #ccc;
-    border-radius: 0.5rem;
+    border-radius: 0.3rem;
     margin: 0 1rem 2rem 0;
     padding: 0.8rem 1rem;
     -webkit-column-break-inside: avoid;
@@ -85,6 +91,7 @@ p {
 .nf-core-pipelines-list .repo_description {
     margin: 5px 0;
     font-size: 0.9rem;
+    text-align: left;
 }
 .latest-release::before {
     content: 'Version: ';

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -55,7 +55,8 @@ p {
     border-radius: 0.3rem;
     text-align: center;
 }
-#production_pipelines, #development_pipelines {
+#pipelines_content > div {
+    display: none; /* Initially hidden whilst loading */
     margin: 2rem 0;
 }
 .nf-core-pipelines-list {
@@ -79,11 +80,11 @@ p {
     page-break-inside: avoid;
     break-inside: avoid-column;
 }
-#nf-core-repos-dev li {
-    background-color: rgba(236, 220, 195, 0.09);
-}
 #nf-core-repos-prod li {
     background-color: rgba(179, 228, 201, 0.08);
+}
+#nf-core-repos-dev li, #archived_pipelines li {
+    background-color: rgba(236, 220, 195, 0.09);
 }
 .nf-core-pipelines-list .repo_name {
     margin-bottom: 0;
@@ -93,19 +94,26 @@ p {
     font-size: 0.9rem;
     text-align: left;
 }
+.nf-core-pipelines-list .pipeline-badge {
+    margin: 5px 0;
+    display: inline-block;
+    border: 1px solid #cccccc;
+    background-color: #ededed;
+    border-radius: 0.2rem;
+    font-size: 0.8rem;
+    padding: 1px 3px;
+    box-shadow: 0 1px 3px #ccc;
+}
 .latest-release::before {
     content: 'Version: ';
     font-weight: normal;
 }
 .nf-core-pipelines-list .latest-release {
-    margin: 5px 0;
-    display: inline-block;
-    border: 1px solid #58AD6B;
-    border-radius: 0.2rem;
-    font-size: 0.8rem;
     background-color: #B5DFBE;
-    padding: 1px 3px;
-    box-shadow: 0 1px 3px #ccc;
+    border-color: #58AD6B;
+    font-weight: bold;
+}
+.nf-core-pipelines-list .archived-lastpush span {
     font-weight: bold;
 }
 .nf-core-pipelines-list .stargazers_count {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -75,11 +75,9 @@ p {
 }
 #nf-core-repos-dev li {
     background-color: rgba(236, 220, 195, 0.09);
-    box-shadow: 0 0 12px 0px rgba(179, 68, 4, 0.25);
 }
 #nf-core-repos-prod li {
     background-color: rgba(179, 228, 201, 0.08);
-    box-shadow: 0 0 12px rgba(25, 120, 119, 0.26);
 }
 .nf-core-pipelines-list .repo_name {
     margin-bottom: 0;

--- a/assets/js/nf-core.js
+++ b/assets/js/nf-core.js
@@ -62,8 +62,7 @@ $(function() {
                         class: 'nf-core-pipelines-list',
                         html: repo_lis.join('')
                     }).appendTo('#production_pipelines');
-                } else {
-                    $('#production_pipelines').hide();
+                    $('#production_pipelines').show();
                 }
 
                 // Pipelines under development
@@ -77,15 +76,20 @@ $(function() {
                         class: 'nf-core-pipelines-list',
                         html: repo_lis.join('')
                     }).appendTo('#development_pipelines');
-                } else {
-                    $('#development_pipelines').hide();
+                    $('#development_pipelines').show();
                 }
+
+                // Show the page content
+                $('#pipelines_content').slideDown();
+                $('#pipelines_loading').slideUp();
 
             });
         }).fail(function(e) {
             console.error("Cannot query GitHub API:", e.responseJSON);
-            $('#production_pipelines').html('<p><em>Oops - there was a problem querying the GitHub API, sorry!</em></p');
-            $('#development_pipelines').hide();
+            $('#pipelines_loading').html(
+                'Oops - there was a problem querying the GitHub API, sorry! <br>' +
+                'Please try again later, or <a href="https://github.com/nf-core/nf-core.github.io/issues">let us know</a>.'
+            );
         });
     }
 });
@@ -104,7 +108,7 @@ function make_pipeline_li(repo){
         stargazers += '<a href="'+repo.stargazers_url+'" class="stargazers_count"><i class="far fa-star"></i> ' + repo.stargazers_count + '</a>';
     }
     return '<li id="repo_'+repo.id+'">' +
-        '<h3 class="repo_name"><a href="'+repo.html_url+'">'+repo.name+'</a></h3> ' +
+        '<h3 class="repo_name"><a href="'+repo.html_url+'">'+repo.full_name+'</a></h3> ' +
         description +
         latest_release +
         stargazers +

--- a/assets/js/nf-core.js
+++ b/assets/js/nf-core.js
@@ -19,12 +19,13 @@ $(function() {
     }
 
     // List available pipelines
-    if ($("meta[property='og:title']").attr("content") == 'Available Pipelines'){
-        // TODO: Currently only gets 100 projects, need proper pagination
+    if ($('body').hasClass('page-pipelines')){
+        // NOTE: Currently only gets 100 projects, need proper pagination
         var org_api_url = "https://api.github.com/orgs/"+github_org+"/repos?per_page=100";
         var repos_ignore = ['cookiecutter', 'tools', 'nf-core.github.io', 'logos', 'test-datasets'];
         var repos_prod = [];
         var repos_dev = [];
+        // TODO: Have another section for archived repositories
         $.getJSON(org_api_url, function(repos) {
             var promises = [];
             $.each(repos, function(idx, repo){
@@ -54,13 +55,7 @@ $(function() {
                 if(repos_prod.length > 0){
                     var repo_lis = [];
                     $.each(repos_prod, function(idx, repo){
-                        repo_lis.push(
-                            '<li id="repo_'+repo.id+'">' +
-                                '<a href="'+repo.html_url+'">'+repo.full_name+'</a> ' +
-                                '<span class="latest-release">'+repo.releases[0].tag_name+'</span>' +
-                            '</li>'
-                        );
-                        console.log('releases 2', repo.name, repo.releases, repo, JSON.parse(JSON.stringify(repo)));
+                        repo_lis.push(make_pipeline_li(repo));
                     });
                     $('<ul/>', {
                         id: 'nf-core-repos-prod',
@@ -75,11 +70,7 @@ $(function() {
                 if(repos_dev.length > 0){
                     var repo_lis = [];
                     $.each(repos_dev, function(idx, repo){
-                        repo_lis.push(
-                            '<li id="repo_'+repo.id+'">' +
-                                '<a href="'+repo.html_url+'">'+repo.full_name+'</a>' +
-                            '</li>'
-                        );
+                        repo_lis.push(make_pipeline_li(repo));
                     });
                     $('<ul/>', {
                         id: 'nf-core-repos-dev',
@@ -98,3 +89,24 @@ $(function() {
         });
     }
 });
+
+function make_pipeline_li(repo){
+    var description = '';
+    if(repo.description){
+        description = '<p class="repo_description">'+repo.description+'</p> ';
+    }
+    var latest_release = '';
+    if(repo.releases.length > 0){
+        latest_release = '<p class="latest-release" title="'+repo.releases[0].name+'">'+repo.releases[0].tag_name+'</p>';
+    }
+    var stargazers = '';
+    if('stargazers_count' in repo){
+        stargazers += '<a href="'+repo.stargazers_url+'" class="stargazers_count"><i class="far fa-star"></i> ' + repo.stargazers_count + '</a>';
+    }
+    return '<li id="repo_'+repo.id+'">' +
+        '<h3 class="repo_name"><a href="'+repo.html_url+'">'+repo.name+'</a></h3> ' +
+        description +
+        latest_release +
+        stargazers +
+    '</li>';
+}

--- a/assets/js/nf-core.js
+++ b/assets/js/nf-core.js
@@ -2,17 +2,99 @@
  * Custom JavaScript for nf-core.github.io
 */
 
+var github_org = 'nf-core';
+
 $(function() {
     // Table of contents styling
     if ( $("#markdown-toc").length ) {
         $(".main-content").addClass('has-toc');
         // Fix the nav position when we scroll
         $(window).scroll(function () {
-            if ($(window).scrollTop() >= $('.site-logo').innerHeight() + $('.page-header').innerHeight()) {
+            if ($(window).scrollTop() >= $('.site-logo').innerHeight() + $('.page-header').innerHeight() + 26) {
                 $('#markdown-toc').addClass('fixed');
             } else {
                 $('#markdown-toc').removeClass('fixed');
             }
+        });
+    }
+
+    // List available pipelines
+    if ($("meta[property='og:title']").attr("content") == 'Available Pipelines'){
+        // TODO: Currently only gets 100 projects, need proper pagination
+        var org_api_url = "https://api.github.com/orgs/"+github_org+"/repos?per_page=100";
+        var repos_ignore = ['cookiecutter', 'tools', 'nf-core.github.io', 'logos', 'test-datasets'];
+        var repos_prod = [];
+        var repos_dev = [];
+        $.getJSON(org_api_url, function(repos) {
+            var promises = [];
+            $.each(repos, function(idx, repo){
+                if(repos_ignore.indexOf(repo.name) == -1){
+                    var releases_api_url = "https://api.github.com/repos/"+repo.full_name+"/releases";
+                    // Call the API endpoint to get information about releases
+                    var jqxhr = $.getJSON(releases_api_url).done(function(releases) {
+                        // Add to the repo object to access this later
+                        repo.releases = releases;
+                        // We have some releases - production pipeline
+                        if(repo.releases.length > 0){
+                            repos_prod.push(repo);
+                        }
+                        // No releases - pipeline in development
+                        else {
+                            repos_dev.push(repo);
+                        }
+                    });
+                    // Save this ajax promise so we can trigger code when it's done
+                    promises.push(jqxhr);
+                }
+            });
+            // Wait for all of the release ajax calls to finish
+            $.when.apply($, promises).done(function(){
+
+                // Production grade pipelines
+                if(repos_prod.length > 0){
+                    var repo_lis = [];
+                    $.each(repos_prod, function(idx, repo){
+                        repo_lis.push(
+                            '<li id="repo_'+repo.id+'">' +
+                                '<a href="'+repo.html_url+'">'+repo.full_name+'</a> ' +
+                                '<span class="latest-release">'+repo.releases[0].tag_name+'</span>' +
+                            '</li>'
+                        );
+                        console.log('releases 2', repo.name, repo.releases, repo, JSON.parse(JSON.stringify(repo)));
+                    });
+                    $('<ul/>', {
+                        id: 'nf-core-repos-prod',
+                        class: 'nf-core-pipelines-list',
+                        html: repo_lis.join('')
+                    }).appendTo('#production_pipelines');
+                } else {
+                    $('#production_pipelines').hide();
+                }
+
+                // Pipelines under development
+                if(repos_dev.length > 0){
+                    var repo_lis = [];
+                    $.each(repos_dev, function(idx, repo){
+                        repo_lis.push(
+                            '<li id="repo_'+repo.id+'">' +
+                                '<a href="'+repo.html_url+'">'+repo.full_name+'</a>' +
+                            '</li>'
+                        );
+                    });
+                    $('<ul/>', {
+                        id: 'nf-core-repos-dev',
+                        class: 'nf-core-pipelines-list',
+                        html: repo_lis.join('')
+                    }).appendTo('#development_pipelines');
+                } else {
+                    $('#development_pipelines').hide();
+                }
+
+            });
+        }).fail(function(e) {
+            console.error("Cannot query GitHub API:", e.responseJSON);
+            $('#production_pipelines').html('<p><em>Oops - there was a problem querying the GitHub API, sorry!</em></p');
+            $('#development_pipelines').hide();
         });
     }
 });

--- a/docs.md
+++ b/docs.md
@@ -15,6 +15,10 @@ The quickest place to get help is on the nf-core Gitter channel: [https://gitter
 For now, the guidelines are pretty simple. The below gives an outline of what is required.
 For more detail, please see the [**list of lint test error codes**](errors).
 
+If in doubt, we recommend using the [nf-core/cookiecutter](https://github.com/nf-core/cookiecutter)
+pipeline template to get started. This generates a skeleton pipeline with all of the featuers
+required to pass the below tests.
+
 ## Features
 All pipelines must adhere to the following:
 

--- a/docs.md
+++ b/docs.md
@@ -16,7 +16,7 @@ For now, the guidelines are pretty simple. The below gives an outline of what is
 For more detail, please see the [**list of lint test error codes**](errors).
 
 If in doubt, we recommend using the [nf-core/cookiecutter](https://github.com/nf-core/cookiecutter)
-pipeline template to get started. This generates a skeleton pipeline with all of the featuers
+pipeline template to get started. This generates a skeleton pipeline with all of the features
 required to pass the below tests.
 
 ## Features

--- a/docs.md
+++ b/docs.md
@@ -33,6 +33,7 @@ All pipelines must adhere to the following:
     * This person should be responsible for basic maintenance and questions
 * The pipeline must not have any failures in the `nf-core lint` tests
     * These tests are run by the [nf-core/tools](https://github.com/nf-core/tools) package and validate the requirements listed on this page.
+    * You can see the list of tests and how to pass them on the [error codes page](errors).
 
 _(any point can be skipped, given a good enough reason...)_
 

--- a/errors.md
+++ b/errors.md
@@ -118,3 +118,9 @@ The `README.md` files for a project are very important and must meet some requir
     ```markdown
     [![Nextflow](https://img.shields.io/badge/nextflow-%E2%89%A50.27.6-brightgreen.svg)](https://www.nextflow.io/)
     ```
+* Bioconda badge
+    * If your pipeline contains a file called `environment.yml`, a bioconda badge is required
+    * Required badge code:
+    ```markdown
+    [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](http://bioconda.github.io/)
+    ```

--- a/pipelines.md
+++ b/pipelines.md
@@ -4,33 +4,22 @@ layout: default
 
 # Available Pipelines
 
-Most pipelines follow conventions seen in the [nf-core/cookiecutter](https://github.com/nf-core/cookiecutter) pipeline template.
+Got another that would fit in well?
+[Let us know!](https://github.com/nf-core/nf-core.github.io/issues/new)
 
-Got another that would fit in well? [Let us know!](https://github.com/nf-core/nf-core.github.io/issues/new)
-
-<div id="production_pipelines">
-    <h2>Production Pipelines</h2>
+<div id="pipelines_loading">
+    <i class="fas fa-spinner fa-pulse"></i> Loading pipelines..
 </div>
 
+<div id="pipelines_content" style="display:none;">
+    <div id="production_pipelines" style="display:none;">
+        <h2>Production Pipelines</h2>
+    </div>
 
-<div id="development_pipelines">
-    <h2>Pipelines in development</h2>
-    <blockquote>
-        <p>These pipelines aren't yet ready for the prime-time, but are under active development.</p>
-        <p>Once they've had a release on GitHub, they will be classed as production-ready pipelines.</p>
-    </blockquote>
+
+    <div id="development_pipelines" style="display:none;">
+        <h2>Pipelines in development</h2>
+        <p>These pipelines aren't yet ready for the prime-time, but are under active development. <br>
+        Once they've had a release on GitHub, they will be classed as production-ready pipelines.</p>
+    </div>
 </div>
-
-### Coming soon...
-It's still early days for the `nf-core` project and we haven't ported many pipelines across just yet. They're coming though! These are the ones that we have in mind:
-
-* [SciLifeLab/NGI-RNAseq](https://github.com/SciLifeLab/NGI-RNAseq)
-* [SciLifeLab/NGI-smRNAseq](https://github.com/SciLifeLab/NGI-smRNAseq)
-* [SciLifeLab/NGI-ChIPseq](https://github.com/SciLifeLab/NGI-ChIPseq)
-* [~~SciLifeLab/NGI-MethylSeq~~](https://github.com/SciLifeLab/NGI-MethylSeq) - _done_
-* [SciLifeLab/NGI-ExoSeq](https://github.com/SciLifeLab/NGI-ExoSeq)
-* [SciLifeLab/NGI-RNAfusion](https://github.com/SciLifeLab/NGI-RNAfusion)
-* [SciLifeLab/NGI-NeutronStar](https://github.com/SciLifeLab/NGI-NeutronStar)
-* [SciLifeLab/NGI-CellRaiser](https://github.com/SciLifeLab/NGI-CellRaiser)
-
-Note that these are not all complete pipelines - some are still under heavy development.

--- a/pipelines.md
+++ b/pipelines.md
@@ -4,19 +4,31 @@ layout: default
 
 # Available Pipelines
 
-Ok, so it's early days and we haven't ported any pipelines across just yet. They're coming though! These are the ones that we have in mind:
+Most pipelines follow conventions seen in the [nf-core/cookiecutter](https://github.com/nf-core/cookiecutter) pipeline template.
+
+Got another that would fit in well? [Let us know!](https://github.com/nf-core/nf-core.github.io/issues/new)
+
+<div id="production_pipelines">
+<h2>Production Pipelines</h2>
+</div>
+
+
+<div id="development_pipelines">
+<h2>Pipelines in development</h2>
+<p>These pipelines aren't yet ready for the prime-time, but are under active development.</p>
+<p>Once they've had a release on GitHub, they will be classed as production-ready pipelines.</p>
+</div>
+
+### Coming soon...
+It's still early days for the `nf-core` project and we haven't ported many pipelines across just yet. They're coming though! These are the ones that we have in mind:
 
 * [SciLifeLab/NGI-RNAseq](https://github.com/SciLifeLab/NGI-RNAseq)
 * [SciLifeLab/NGI-smRNAseq](https://github.com/SciLifeLab/NGI-smRNAseq)
 * [SciLifeLab/NGI-ChIPseq](https://github.com/SciLifeLab/NGI-ChIPseq)
-* [SciLifeLab/NGI-MethylSeq](https://github.com/SciLifeLab/NGI-MethylSeq)
+* [~~SciLifeLab/NGI-MethylSeq~~](https://github.com/SciLifeLab/NGI-MethylSeq) - _done_
 * [SciLifeLab/NGI-ExoSeq](https://github.com/SciLifeLab/NGI-ExoSeq)
 * [SciLifeLab/NGI-RNAfusion](https://github.com/SciLifeLab/NGI-RNAfusion)
 * [SciLifeLab/NGI-NeutronStar](https://github.com/SciLifeLab/NGI-NeutronStar)
 * [SciLifeLab/NGI-CellRaiser](https://github.com/SciLifeLab/NGI-CellRaiser)
 
 Note that these are not all complete pipelines - some are still under heavy development.
-
-Most pipelines follow conventions seen in the [nf-core/cookiecutter](https://github.com/nf-core/cookiecutter) pipeline template.
-
-Got another that would fit in well? [Let us know!](https://github.com/nf-core/nf-core.github.io/issues/new)

--- a/pipelines.md
+++ b/pipelines.md
@@ -4,22 +4,24 @@ layout: default
 
 # Available Pipelines
 
-Got another that would fit in well?
+Can you think of another pipeline that would fit in well?
 [Let us know!](https://github.com/nf-core/nf-core.github.io/issues/new)
 
 <div id="pipelines_loading">
     <i class="fas fa-spinner fa-pulse"></i> Loading pipelines..
 </div>
 
-<div id="pipelines_content" style="display:none;">
-    <div id="production_pipelines" style="display:none;">
+<div id="pipelines_content">
+    <div id="production_pipelines">
         <h2>Production Pipelines</h2>
     </div>
-
-
-    <div id="development_pipelines" style="display:none;">
+    <div id="development_pipelines">
         <h2>Pipelines in development</h2>
         <p>These pipelines aren't yet ready for the prime-time, but are under active development. <br>
         Once they've had a release on GitHub, they will be classed as production-ready pipelines.</p>
+    </div>
+    <div id="archived_pipelines">
+        <h2>Archived pipelines</h2>
+        <p>These pipelines have been archived and are no longer under active development.</p>
     </div>
 </div>

--- a/pipelines.md
+++ b/pipelines.md
@@ -9,14 +9,16 @@ Most pipelines follow conventions seen in the [nf-core/cookiecutter](https://git
 Got another that would fit in well? [Let us know!](https://github.com/nf-core/nf-core.github.io/issues/new)
 
 <div id="production_pipelines">
-<h2>Production Pipelines</h2>
+    <h2>Production Pipelines</h2>
 </div>
 
 
 <div id="development_pipelines">
-<h2>Pipelines in development</h2>
-<p>These pipelines aren't yet ready for the prime-time, but are under active development.</p>
-<p>Once they've had a release on GitHub, they will be classed as production-ready pipelines.</p>
+    <h2>Pipelines in development</h2>
+    <blockquote>
+        <p>These pipelines aren't yet ready for the prime-time, but are under active development.</p>
+        <p>Once they've had a release on GitHub, they will be classed as production-ready pipelines.</p>
+    </blockquote>
 </div>
 
 ### Coming soon...


### PR DESCRIPTION
First draft of the new pipelines page, using the GitHub API to fetch the projects.

Projects are split into two lists according to whether they have any releases or not. In a future update I can add a third list for repositories that are archived.

The styling isn't super pretty, but hopefully it's a start. We can also think about what other information would be useful to display.

---

Screenshot:
![image](https://user-images.githubusercontent.com/465550/37376075-e9923610-2722-11e8-8529-d056148555dd.png)

---

Demo with a different GitHub organisation that has more repos (with releases):

![127 0 0 1_4000_pipelines](https://user-images.githubusercontent.com/465550/37376132-3c9ca53e-2723-11e8-967a-aa141c6024bb.png)
