### PR TITLE
Rewrite CSS columns for pipelines to make wrapping work properly.

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -62,11 +62,10 @@ p {
 .nf-core-pipelines-list {
     margin: 0 0 3rem;
     padding: 0;
-    -webkit-column-width: 25rem;
-    -moz-column-width: 25rem;
-    -o-column-width: 25rem;
-    -ms-column-width: 25rem;
-    column-width: 25rem;
+    display: -webkit-flex;
+    display: flex;
+    -webkit-flex-wrap: wrap;
+    flex-wrap: wrap;
 }
 .nf-core-pipelines-list li {
     position: relative;


### PR DESCRIPTION
Instead of this:
![image](https://user-images.githubusercontent.com/465550/38942099-402f96b2-432e-11e8-9242-51bc5d4c9785.png)


We want this:
![image](https://user-images.githubusercontent.com/465550/38942101-45a3947c-432e-11e8-8c8a-22cca207d433.png)
